### PR TITLE
Implement sidebar navigation components

### DIFF
--- a/apps/frontend/src/components/app-sidebar.tsx
+++ b/apps/frontend/src/components/app-sidebar.tsx
@@ -1,0 +1,117 @@
+import * as React from "react";
+import {
+  LayoutDashboard,
+  Users,
+  ArrowRightLeft,
+  Wallet,
+  Package,
+} from "lucide-react";
+import { useNavigate, useLocation } from "react-router-dom";
+
+import { NavMain } from "@/components/nav-main";
+import { NavUser } from "@/components/nav-user";
+import { AppSwitcher } from "@/components/app-switcher";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarHeader,
+  SidebarRail,
+} from "@/components/ui/sidebar";
+import { useLogoutMutation } from "@/store/auth-slice";
+
+// Centralized navigation configuration with breadcrumb support
+export const navigationConfig = {
+  apps: [
+    {
+      name: "Salary Manager",
+      path: "/salary",
+      icon: Wallet,
+    },
+    {
+      name: "Inventory Manager",
+      path: "/inventory",
+      icon: Package,
+    },
+  ],
+  salaryNav: [
+    {
+      title: "Salaries",
+      url: "/salary",
+      icon: LayoutDashboard,
+      breadcrumbs: [{ label: "Salaries", url: "/salary" }],
+    },
+    {
+      title: "Employees",
+      url: "/salary/employees",
+      icon: Users,
+      breadcrumbs: [{ label: "Employees", url: "/salary/employees" }],
+    },
+    {
+      title: "Payments",
+      url: "/salary/payments",
+      icon: ArrowRightLeft,
+      breadcrumbs: [{ label: "Payment History", url: "/salary/payments" }],
+    },
+  ],
+  inventoryNav: [
+    {
+      title: "Home",
+      url: "/inventory",
+      icon: Package,
+      breadcrumbs: [{ label: "Inventory", url: "/inventory" }],
+    },
+  ],
+  // Additional routes not in sidebar navigation
+  additionalRoutes: [
+    {
+      pattern: /^\/salary\/payments\/[^/]+$/,
+      breadcrumbs: [
+        { label: "Payment History", url: "/salary/payments" },
+        { label: "Transfer Details", url: null }, // null means current page, not clickable
+      ],
+    },
+  ],
+};
+
+// Keep data for internal use
+const data = navigationConfig;
+
+export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [logout, { isLoading: isLoggingOut }] = useLogoutMutation();
+
+  const currentApp =
+    data.apps.find((app) => location.pathname.startsWith(app.path)) ||
+    data.apps[0];
+
+  // Determine which nav items to show based on current app
+  const navItems = location.pathname.startsWith("/inventory")
+    ? data.inventoryNav
+    : data.salaryNav;
+
+  const handleLogout = async () => {
+    try {
+      await logout().unwrap();
+      navigate("/login");
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  return (
+    <Sidebar collapsible="icon" {...props}>
+      <SidebarHeader>
+        <AppSwitcher apps={data.apps} currentApp={currentApp} />
+      </SidebarHeader>
+      <SidebarContent>
+        <NavMain items={navItems} />
+      </SidebarContent>
+      <SidebarFooter>
+        <NavUser onLogout={handleLogout} isLoggingOut={isLoggingOut} />
+      </SidebarFooter>
+      <SidebarRail />
+    </Sidebar>
+  );
+}

--- a/apps/frontend/src/components/app-switcher.tsx
+++ b/apps/frontend/src/components/app-switcher.tsx
@@ -1,0 +1,78 @@
+import { ChevronsUpDown, type LucideIcon } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from "@/components/ui/sidebar";
+
+export function AppSwitcher({
+  apps,
+  currentApp,
+}: {
+  apps: {
+    name: string;
+    path: string;
+    icon: LucideIcon;
+  }[];
+  currentApp: {
+    name: string;
+    path: string;
+    icon: LucideIcon;
+  };
+}) {
+  const navigate = useNavigate();
+
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <SidebarMenuButton
+              size="lg"
+              className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+            >
+              <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-blue-600 text-white">
+                <currentApp.icon className="size-4" />
+              </div>
+              <div className="grid flex-1 text-left text-sm leading-tight">
+                <span className="truncate font-semibold">CMHO</span>
+                <span className="truncate text-xs">{currentApp.name}</span>
+              </div>
+              <ChevronsUpDown className="ml-auto" />
+            </SidebarMenuButton>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            className="w-[--radix-dropdown-menu-trigger-width] min-w-56 rounded-lg"
+            align="start"
+            side="bottom"
+            sideOffset={4}
+          >
+            {apps.map((app) => {
+              const Icon = app.icon;
+              return (
+                <DropdownMenuItem
+                  key={app.path}
+                  onClick={() => navigate(app.path)}
+                  className="gap-2 p-2 cursor-pointer"
+                >
+                  <div className="flex size-6 items-center justify-center rounded-sm border">
+                    <Icon className="size-4 shrink-0" />
+                  </div>
+                  {app.name}
+                </DropdownMenuItem>
+              );
+            })}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  );
+}

--- a/apps/frontend/src/components/nav-main.tsx
+++ b/apps/frontend/src/components/nav-main.tsx
@@ -1,0 +1,45 @@
+import { type LucideIcon } from "lucide-react"
+import { NavLink, useLocation } from "react-router-dom"
+
+import {
+  SidebarGroup,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from "@/components/ui/sidebar"
+
+export function NavMain({
+  items,
+}: {
+  items: {
+    title: string
+    url: string
+    icon?: LucideIcon
+  }[]
+}) {
+  const location = useLocation()
+
+  return (
+    <SidebarGroup>
+      <SidebarMenu>
+        {items.map((item) => {
+          const isActive = item.url === "/salary" 
+            ? location.pathname === "/salary"
+            : location.pathname.startsWith(item.url)
+          
+          return (
+            <SidebarMenuItem key={item.title}>
+              <SidebarMenuButton asChild tooltip={item.title} isActive={isActive}>
+                <NavLink to={item.url}>
+                  {item.icon && <item.icon />}
+                  <span>{item.title}</span>
+                </NavLink>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          )
+        })}
+      </SidebarMenu>
+    </SidebarGroup>
+  )
+}
+

--- a/apps/frontend/src/components/nav-user.tsx
+++ b/apps/frontend/src/components/nav-user.tsx
@@ -1,0 +1,48 @@
+import {
+  LogOut,
+  User2,
+} from "lucide-react"
+
+import {
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from "@/components/ui/sidebar"
+
+export function NavUser({
+  onLogout,
+  isLoggingOut,
+}: {
+  onLogout: () => void
+  isLoggingOut: boolean
+}) {
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <SidebarMenuButton
+          size="lg"
+          className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+        >
+          <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-gray-200 text-gray-600">
+            <User2 className="size-4" />
+          </div>
+          <div className="grid flex-1 text-left text-sm leading-tight">
+            <span className="truncate font-semibold">Admin</span>
+            <span className="truncate text-xs">admin@cmho.com</span>
+          </div>
+        </SidebarMenuButton>
+      </SidebarMenuItem>
+      <SidebarMenuItem>
+        <SidebarMenuButton
+          onClick={onLogout}
+          disabled={isLoggingOut}
+          tooltip="Logout"
+        >
+          <LogOut />
+          <span>Logout</span>
+        </SidebarMenuButton>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  )
+}
+


### PR DESCRIPTION
# Pull Request 

## :spiral_notepad: Description

This PR implements the core sidebar navigation components that compose the shadcn/ui primitives (from PR #5) into a functional sidebar navigation system. These components provide the structure for app navigation, app switching, and user menu functionality.

This builds on the UI primitives added in the previous PR and creates the actual navigation experience, though it's not yet integrated into the app pages (that will come in the next PR).

## :ticket: Github issue link

N/A - Part 2 of sidebar navigation implementation series (follows PR #5)

## :pencil2: Changes

- **app-sidebar.tsx** - Main sidebar container that orchestrates the navigation structure with app switcher, nav menu, and user section
- **nav-main.tsx** - Navigation menu component that renders the main app navigation items (Dashboard, Employees, Payments) with active state highlighting
- **app-switcher.tsx** - Application switcher component allowing users to toggle between Salary Manager and Inventory Manager
- **nav-user.tsx** - User profile section with logout functionality in the sidebar footer

## :camera_flash: Screenshots

These components compose together to create the complete sidebar navigation experience. Full integration with app pages will be in the next PR.

---

**Note**: This PR is part 2 of a series. The sidebar integration with Layout component and app pages will come in the next PR.