### PR TITLE
refactor/simplify-inventory-unit-structure

### DIFF
--- a/apps/frontend/src/components/AddInventoryForm.tsx
+++ b/apps/frontend/src/components/AddInventoryForm.tsx
@@ -17,10 +17,9 @@ import {
   InventoryType,
   InventoryStatus,
   UnitLevel,
-  UnitGrouping,
 } from "@/types/inventory";
 import {
-  getDefaultGrouping,
+  getDefaultUnits,
   INVENTORY_CATEGORIES,
 } from "@/lib/inventory-defaults";
 import { storageService } from "@/lib/inventory-storage";
@@ -34,10 +33,9 @@ export function AddInventoryForm({ onClose, onSave }: AddInventoryFormProps) {
   const [inventoryType, setInventoryType] = useState<InventoryType>("Drug");
   const [name, setName] = useState("");
 
-  // Initialize units synchronously with default grouping to prevent UI flash
+  // Initialize units synchronously with defaults to prevent UI flash
   const getInitialUnits = () => {
-    const defaultGrouping = getDefaultGrouping("Drug");
-    return defaultGrouping.units;
+    return getDefaultUnits("Drug");
   };
 
   const [units, setUnits] = useState<UnitLevel[]>(getInitialUnits);
@@ -51,9 +49,9 @@ export function AddInventoryForm({ onClose, onSave }: AddInventoryFormProps) {
   };
 
   useEffect(() => {
-    const defaultGrouping = getDefaultGrouping(inventoryType);
-    setUnits(defaultGrouping.units);
-    setInitialUnits(defaultGrouping.units);
+    const defaultUnits = getDefaultUnits(inventoryType);
+    setUnits(defaultUnits);
+    setInitialUnits(defaultUnits);
   }, [inventoryType]);
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -71,20 +69,13 @@ export function AddInventoryForm({ onClose, onSave }: AddInventoryFormProps) {
       return;
     }
 
-    const grouping: UnitGrouping = {
-      id: `grouping-${Date.now()}`,
-      name: `${inventoryType} - ${units[0]?.name}`,
-      units,
-    };
-
     const item: InventoryItem = {
-      id: `item-${Date.now()}`,
+      id: crypto.randomUUID(),
       name,
       description: "",
       category: "",
       inventoryType,
-      groupingId: grouping.id,
-      grouping: grouping,
+      units,
       status,
       stocks: [],
     };

--- a/apps/frontend/src/components/InventoryList.tsx
+++ b/apps/frontend/src/components/InventoryList.tsx
@@ -55,7 +55,7 @@ export function InventoryList({
   };
 
   const getBaseUnitName = (item: InventoryItem): string => {
-    const units = item.grouping?.units || [];
+    const units = item.units || [];
     // Base unit is the last unit in the array
     const baseUnit = units.length > 0 ? units[units.length - 1] : null;
     return baseUnit?.name || "units";
@@ -73,7 +73,7 @@ export function InventoryList({
   ): string => {
     if (totalInBaseUnits === 0) return `0 ${getBaseUnitName(item)}`;
 
-    const units = item.grouping?.units || [];
+    const units = item.units || [];
     if (units.length === 0)
       return `${totalInBaseUnits} ${getBaseUnitName(item)}`;
 

--- a/apps/frontend/src/components/modals/AddStockModal.tsx
+++ b/apps/frontend/src/components/modals/AddStockModal.tsx
@@ -47,7 +47,7 @@ export function AddStockModal({
     if (item) {
       setInventoryItem(item);
       // Initialize quantity inputs for all units
-      const sortedUnits = getSortedUnits(item.grouping.units);
+      const sortedUnits = getSortedUnits(item.units);
       setQuantityInputs(
         sortedUnits.map((unit) => ({ unitId: unit.id, value: "0" }))
       );
@@ -67,7 +67,7 @@ export function AddStockModal({
 
   const getBaseUnit = () => {
     if (!inventoryItem) return null;
-    const units = inventoryItem.grouping.units;
+    const units = inventoryItem.units;
     // Base unit is the last unit in the array
     return units.length > 0 ? units[units.length - 1] : null;
   };
@@ -75,7 +75,7 @@ export function AddStockModal({
   const calculateTotalInBaseUnits = () => {
     if (!inventoryItem) return 0;
 
-    const units = inventoryItem.grouping.units;
+    const units = inventoryItem.units;
     let total = 0;
 
     units.forEach((unit, unitIndex) => {
@@ -139,7 +139,7 @@ export function AddStockModal({
     }
 
     const stockEntry: StockEntry = {
-      id: `stock-${Date.now()}`,
+      id: crypto.randomUUID(),
       inventoryItemId: inventoryItem.id,
       costPrice: parseFloat(costPrice),
       sellingPrice: parseFloat(sellingPrice),
@@ -164,7 +164,7 @@ export function AddStockModal({
   if (!inventoryItem) return <EmptyState />;
 
   const baseUnit = getBaseUnit();
-  const sortedUnits = getSortedUnits(inventoryItem.grouping.units);
+  const sortedUnits = getSortedUnits(inventoryItem.units);
   const totalInBaseUnits = calculateTotalInBaseUnits();
 
   const profit = calculateProfit();

--- a/apps/frontend/src/components/modals/EditInventoryModal.tsx
+++ b/apps/frontend/src/components/modals/EditInventoryModal.tsx
@@ -17,8 +17,8 @@ import {
   InventoryType,
   InventoryStatus,
   UnitLevel,
-  UnitGrouping,
 } from "@/types/inventory";
+import { INVENTORY_CATEGORIES } from "@/lib/inventory-defaults";
 import { storageService } from "@/lib/inventory-storage";
 
 interface EditInventoryModalProps {
@@ -36,10 +36,8 @@ export function EditInventoryModal({
     item.inventoryType
   );
   const [name, setName] = useState(item.name);
-  const [units, setUnits] = useState<UnitLevel[]>(item.grouping?.units || []);
-  const [initialUnits] = useState<UnitLevel[]>(
-    item.grouping?.units || []
-  );
+  const [units, setUnits] = useState<UnitLevel[]>(item.units || []);
+  const [initialUnits] = useState<UnitLevel[]>(item.units || []);
   const [status, setStatus] = useState<InventoryStatus>(item.status);
 
   const getBaseUnit = (): UnitLevel | undefined => {
@@ -68,25 +66,16 @@ export function EditInventoryModal({
       return;
     }
 
-    // Update or create new grouping
-    const grouping: UnitGrouping = {
-      id: item.grouping?.id || `grouping-${Date.now()}`,
-      name: `${inventoryType} - ${units[0]?.name}`,
-      units,
-    };
-
     const updatedItem: InventoryItem = {
       ...item,
       name,
       inventoryType,
-      groupingId: grouping.id,
-      grouping: grouping,
+      units,
       status,
     };
 
     // Save to local storage
     storageService.saveItem(updatedItem);
-    storageService.saveGrouping(grouping);
 
     onSave(updatedItem);
     onClose();
@@ -151,11 +140,11 @@ export function EditInventoryModal({
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="Drug">Drug</SelectItem>
-                    <SelectItem value="Injection">Injection</SelectItem>
-                    <SelectItem value="Syrup">Syrup</SelectItem>
-                    <SelectItem value="Bottle">Bottle</SelectItem>
-                    <SelectItem value="Equipment">Equipment</SelectItem>
+                    {Object.values(INVENTORY_CATEGORIES).map((category) => (
+                      <SelectItem key={category.id} value={category.name}>
+                        {category.name}
+                      </SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
               </div>

--- a/apps/frontend/src/lib/inventory-defaults.ts
+++ b/apps/frontend/src/lib/inventory-defaults.ts
@@ -1,4 +1,4 @@
-import { UnitGrouping, InventoryType } from "@/types/inventory";
+import { UnitLevel, InventoryType } from "@/types/inventory";
 
 // All unique units extracted from INVENTORY_CATEGORIES
 export const PACKAGE_UNITS = {
@@ -35,20 +35,21 @@ export const INVENTORY_CATEGORIES = {
     name: "Consumable",
     units: [PACKAGE_UNITS.piece],
   },
-} as const satisfies Record<string, UnitGrouping>;
+} as const satisfies Record<
+  string,
+  { id: string; name: string; units: readonly UnitLevel[] }
+>;
 
-// Hydrate preset grouping with runtime fields (quantity)
-export function hydrateGrouping(grouping: UnitGrouping): UnitGrouping {
-  const hydratedUnits = grouping.units.map((unit) => ({
+// Hydrate preset units with runtime fields (quantity)
+export function hydrateUnits(units: readonly UnitLevel[]): UnitLevel[] {
+  return units.map((unit) => ({
     ...unit,
     quantity: "",
   }));
-
-  return { ...grouping, units: hydratedUnits };
 }
 
-export function getDefaultGrouping(type: InventoryType): UnitGrouping {
-  return hydrateGrouping(INVENTORY_CATEGORIES[type]);
+export function getDefaultUnits(type: InventoryType): UnitLevel[] {
+  return hydrateUnits(INVENTORY_CATEGORIES[type].units);
 }
 
 // Extract all unique unit names from PACKAGE_UNITS

--- a/apps/frontend/src/lib/inventory-storage.ts
+++ b/apps/frontend/src/lib/inventory-storage.ts
@@ -1,7 +1,6 @@
-import { InventoryItem, UnitGrouping } from '@/types/inventory';
+import { InventoryItem } from '@/types/inventory';
 
 const INVENTORY_KEY = 'hospital_inventory_items';
-const GROUPINGS_KEY = 'hospital_unit_groupings';
 
 export const storageService = {
   getItems(): InventoryItem[] {
@@ -25,29 +24,6 @@ export const storageService = {
   deleteItem(id: string): void {
     const items = this.getItems().filter(i => i.id !== id);
     localStorage.setItem(INVENTORY_KEY, JSON.stringify(items));
-  },
-
-  getGroupings(): UnitGrouping[] {
-    const data = localStorage.getItem(GROUPINGS_KEY);
-    return data ? JSON.parse(data) : [];
-  },
-
-  saveGrouping(grouping: UnitGrouping): void {
-    const groupings = this.getGroupings();
-    const existingIndex = groupings.findIndex(g => g.id === grouping.id);
-
-    if (existingIndex >= 0) {
-      groupings[existingIndex] = grouping;
-    } else {
-      groupings.push(grouping);
-    }
-
-    localStorage.setItem(GROUPINGS_KEY, JSON.stringify(groupings));
-  },
-
-  deleteGrouping(id: string): void {
-    const groupings = this.getGroupings().filter(g => g.id !== id);
-    localStorage.setItem(GROUPINGS_KEY, JSON.stringify(groupings));
   }
 };
 

--- a/apps/frontend/src/types/inventory.ts
+++ b/apps/frontend/src/types/inventory.ts
@@ -9,13 +9,6 @@ export interface UnitLevel {
   quantity?: number | string; // Runtime field for conversion factor (user input)
 }
 
-export interface UnitGrouping {
-  id: string;
-  name: string;
-  units: UnitLevel[];
-  createdAt?: string;
-}
-
 // Derive the InventoryType from the keys of INVENTORY_CATEGORIES
 export type InventoryType = keyof typeof INVENTORY_CATEGORIES;
 
@@ -37,8 +30,7 @@ export interface InventoryItem {
   description: string;
   category: string;
   inventoryType: InventoryType;
-  groupingId: string;
-  grouping: UnitGrouping;
+  units: UnitLevel[];
   status: InventoryStatus;
   stocks?: StockEntry[];
 }


### PR DESCRIPTION
# Pull Request

## :spiral_notepad: Description

This refactoring simplifies the inventory management system by removing the `UnitGrouping` abstraction layer and storing unit levels directly on inventory items. This change makes the data structure more straightforward and reduces unnecessary indirection.

## :ticket: GitHub Issue

N/A

## :link: Related PRs

N/A

## :pencil2: Changes

- Removed `UnitGrouping` interface from inventory types
- Updated `InventoryItem` to store `units` array directly instead of `groupingId` and `grouping` reference
- Removed grouping-related methods from storage service (`getGroupings`, `saveGrouping`, `deleteGrouping`)
- Refactored `inventory-defaults.ts` to use `hydrateUnits` and `getDefaultUnits` instead of grouping-based functions
- Updated `AddInventoryForm` to work with units directly without creating separate grouping objects
- Updated `InventoryList` to access units from `item.units` instead of `item.grouping.units`
- Updated `AddStockModal` to access units from `inventoryItem.units` instead of `inventoryItem.grouping.units`
- Updated `EditInventoryModal` to work with units directly and removed grouping save logic
- Changed ID generation from timestamp-based to `crypto.randomUUID()` for better uniqueness
- Improved `EditInventoryModal` to dynamically populate inventory types from `INVENTORY_CATEGORIES`

## :camera_flash: Screenshots

N/A